### PR TITLE
fix: migration schema table DDL

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -410,7 +410,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 		return nil
 	}
 
-	query = `CREATE TABLE IF NOT EXISTS ` + pq.QuoteIdentifier(p.config.migrationsSchemaName) + `.` + pq.QuoteIdentifier(p.config.migrationsTableName) + ` (version bigint not null primary key, dirty boolean not null)`
+	query = `CREATE TABLE IF NOT EXISTS ` + pq.QuoteIdentifier(p.config.migrationsSchemaName) + `.` + pq.QuoteIdentifier(p.config.migrationsTableName) + ` (id SERIAL PRIMARY KEY, migration_timestamp BIGINT UNIQUE NOT NULL, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), dirty BOOLEAN NOT NULL DEFAULT true)`
 	if _, err = p.conn.ExecContext(context.Background(), query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}


### PR DESCRIPTION
This PR updates the migrations table schema by replacing version bigint with id SERIAL PRIMARY KEY and adding migration_timestamp BIGINT UNIQUE NOT NULL, and applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(). This provides better tracking and management of database migrations.